### PR TITLE
feat(gcp-detector): add Cloud Run support with faas.*

### DIFF
--- a/detectors/node/opentelemetry-resource-detector-gcp/src/detectors/GcpDetector.ts
+++ b/detectors/node/opentelemetry-resource-detector-gcp/src/detectors/GcpDetector.ts
@@ -34,6 +34,10 @@ import {
   SEMRESATTRS_K8S_CLUSTER_NAME,
   SEMRESATTRS_K8S_NAMESPACE_NAME,
   SEMRESATTRS_K8S_POD_NAME,
+  SEMRESATTRS_FAAS_NAME,
+  SEMRESATTRS_FAAS_INSTANCE,
+  SEMRESATTRS_FAAS_VERSION,
+
 } from '@opentelemetry/semantic-conventions';
 
 /**
@@ -64,6 +68,15 @@ class GcpDetector implements ResourceDetector {
       [SEMRESATTRS_HOST_NAME]: this._getHostname(isAvail),
       [SEMRESATTRS_CLOUD_AVAILABILITY_ZONE]: this._getZone(isAvail),
     };
+
+    // Add resource attributes for Cloud Run.
+    if (process.env.K_SERVICE) {
+      attributes[SEMRESATTRS_FAAS_NAME] = process.env.K_SERVICE;
+      attributes[SEMRESATTRS_FAAS_VERSION] = process.env.K_REVISION;
+      attributes[SEMRESATTRS_FAAS_INSTANCE] = (async () => {
+        return (await isAvail) ? this._getInstanceId(isAvail) : undefined;
+      })();
+    }
 
     // Add resource attributes for K8s.
     if (process.env.KUBERNETES_SERVICE_HOST) {

--- a/detectors/node/opentelemetry-resource-detector-gcp/src/detectors/GcpDetector.ts
+++ b/detectors/node/opentelemetry-resource-detector-gcp/src/detectors/GcpDetector.ts
@@ -37,7 +37,6 @@ import {
   SEMRESATTRS_FAAS_NAME,
   SEMRESATTRS_FAAS_INSTANCE,
   SEMRESATTRS_FAAS_VERSION,
-
 } from '@opentelemetry/semantic-conventions';
 
 /**

--- a/detectors/node/opentelemetry-resource-detector-gcp/src/detectors/GcpDetector.ts
+++ b/detectors/node/opentelemetry-resource-detector-gcp/src/detectors/GcpDetector.ts
@@ -72,9 +72,7 @@ class GcpDetector implements ResourceDetector {
     if (process.env.K_SERVICE) {
       attributes[SEMRESATTRS_FAAS_NAME] = process.env.K_SERVICE;
       attributes[SEMRESATTRS_FAAS_VERSION] = process.env.K_REVISION;
-      attributes[SEMRESATTRS_FAAS_INSTANCE] = (async () => {
-        return (await isAvail) ? this._getInstanceId(isAvail) : undefined;
-      })();
+      attributes[SEMRESATTRS_FAAS_INSTANCE] = this._getInstanceId(isAvail);
     }
 
     // Add resource attributes for K8s.

--- a/detectors/node/opentelemetry-resource-detector-gcp/test/detectors/GcpDetector.test.ts
+++ b/detectors/node/opentelemetry-resource-detector-gcp/test/detectors/GcpDetector.test.ts
@@ -223,7 +223,7 @@ describe('gcpDetector', () => {
     
       const attrs = resource.attributes;
     
-      // Inline attribute checks (style-consistent with other helpers)
+      // This should be moved to the @opentelemetry/contrib-test-utils and replaced once available.
       if (
         attrs['faas.name'] !== 'my-cloud-run-service' ||
         attrs['faas.version'] !== 'my-cloud-run-revision' ||


### PR DESCRIPTION
## Which problem is this PR solving?

The GCP resource detector for Node.js did not previously support Cloud Run–specific resource attributes, although these are supported in other SDKs (e.g. Go, Java). This PR adds support for setting the `faas.*` attributes when running in a Cloud Run environment.

## Short description of the changes

- Detects `faas.name` from `K_SERVICE` environment variable
- Detects `faas.version` from `K_REVISION` environment variable
- Detects `faas.instance` from GCP metadata server (`/instance/id`)
- Adds unit test for Cloud Run detection, following existing patterns
- Keeps full backward compatibility and aligns behavior with the Go SDK implementation (using env vars when guaranteed)
